### PR TITLE
Fix "decent" image URL

### DIFF
--- a/src/dictEntries.txt
+++ b/src/dictEntries.txt
@@ -42,7 +42,7 @@
 
 	"shame": "http://i.imgur.com/FidZknJ.gif",
 	"power": "http://i.imgur.com/8Igah2t.png",
-	"decent": "Here is Twintop's best StM to date:\nhttps://puu.sh/qgWCQ/f565207eb0.jpg",
+	"decent": "Here is Twintop's best StM to date:\nhttps://cdn.discordapp.com/attachments/524189841026580480/969575253913247744/20220429_222506.jpg",
 	"racial": "Racials are extraordinarily close to one another in ~~Legion~~~~BFA~~Shadowlands, comprising less than a 1% difference. That being said, it may be useful to look at things like Arcane Torrent, Rocket Jump, and Darkflight. Otherwise, just go for whatever race you enjoy playing.\n\nTL;DR: \"Follow your :heart:\"\n~Hygeia 2016",
 	"fantasy": "http://i.imgur.com/EMSiUF3.jpg",
 	"simsOld": "stm",


### PR DESCRIPTION
Change the old puush image URL (now 404s) to a Discord CDN hosted one.